### PR TITLE
Update holiday.cpp

### DIFF
--- a/src/holiday.cpp
+++ b/src/holiday.cpp
@@ -35,8 +35,7 @@ bool getHolidays(Holiday& result, int year, int month) {
     }
     http.end();
 
-    int status = doc["code"];
-    if (doc["code"] != 0) {
+    if (int status = doc["code"]) {
         Serial.println("Get holidays error.");
         return false;
     }


### PR DESCRIPTION
ArduinoJson 7.3 开始，MemberProxy 和 ElementProxy 变更为non-copyable，所以doc["code"]必须先显式转换到int再做判断。